### PR TITLE
determine map variable instead of hardcoding

### DIFF
--- a/screenshot.js
+++ b/screenshot.js
@@ -90,8 +90,12 @@ page.open(intel_url, function () {
             map.style.left = 0;
 
             document.getElementById('snapcontrol').style.display = 'none';
-
-            K.setOptions({disableDefaultUI: true});
+            
+            for (var i in window) {
+              if (window[i] && window[i].setOptions) {
+                window[i].setOptions({disableDefaultUI: true});
+              }
+            }
         }, portal_min_level, portal_max_level);
 
         console.log('loading intel...');


### PR DESCRIPTION
Niantic have changed the Google map object variable name from K to L. I think they change variable names fairly frequently (re-obfuscated on every build) so it might be best to automatically determine which variable is the map.
